### PR TITLE
JSCO-49: Improve error handling on retries exceeded

### DIFF
--- a/lib/cluster.ts
+++ b/lib/cluster.ts
@@ -113,6 +113,8 @@ export interface ClusterOptions {
 
   /**
    * Specifies the default maximum number of retries for operations performed by the SDK. Defaults to 7.
+   *
+   * Volatile: This API is subject to change at any time.
    */
   maxRetries?: number
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -42,7 +42,7 @@ export class InvalidCredentialError extends AnalyticsError {
 }
 
 /**
- * Indicates that an interaction with the Columnar cluster does not complete before its timeout expires.
+ * Indicates that an interaction with the Analytics cluster does not complete before its timeout expires.
  *
  * @category Error Handling
  */
@@ -73,6 +73,13 @@ export class QueryError extends AnalyticsError {
     super(message)
     this.serverMessage = serverMessage
     this.code = code
+  }
+
+  /**
+   * @internal
+   */
+  addMessagePrefix(prefix: string): void {
+    this.message = prefix + this.message
   }
 }
 

--- a/lib/internalerrors.ts
+++ b/lib/internalerrors.ts
@@ -1,20 +1,11 @@
 /**
- * Indicates that we failed to connect to a node within the timeout period.
+ * Indicates that we failed to connect to a node within the timeout period, but still want to retry if possible.
  *
  * @internal
  */
 export class InternalConnectionTimeout extends Error {
-  private dnsRecord: string
-  constructor(dnsRecord: string) {
+  constructor() {
     super('Timed out waiting to connect to node')
-    this.dnsRecord = dnsRecord
-  }
-
-  /**
-   * @internal
-   */
-  get DnsRecord(): string {
-    return this.dnsRecord
   }
 }
 
@@ -24,19 +15,19 @@ export class InternalConnectionTimeout extends Error {
  * @internal
  */
 export class HttpStatusError extends Error {
-  private statusCode: number
+  private _statusCode: number
 
   constructor(statusCode: number) {
     super('HttpStatusCode error: ' + statusCode)
     this.name = this.constructor.name
-    this.statusCode = statusCode
+    this._statusCode = statusCode
   }
 
   /**
    * @internal
    */
-  get StatusCode(): number {
-    return this.statusCode
+  get statusCode(): number {
+    return this._statusCode
   }
 }
 
@@ -47,15 +38,13 @@ export class HttpStatusError extends Error {
  */
 export class ConnectionError extends Error {
   private request: boolean
-  private dnsRecord?: string
   cause?: Error
 
-  constructor(err: Error, request: boolean, dnsRecord?: string) {
+  constructor(err: Error, request: boolean) {
     super(`ConnectionError: ${err.message}`)
     this.name = this.constructor.name
     this.cause = err
     this.request = request
-    this.dnsRecord = dnsRecord
   }
 
   /**
@@ -63,23 +52,6 @@ export class ConnectionError extends Error {
    */
   get isRequestError(): boolean {
     return this.request
-  }
-
-  /**
-   * @internal
-   */
-  get DnsRecord(): string | undefined {
-    return this.dnsRecord
-  }
-}
-
-/**
- * @internal
- */
-export class DnsRecordsExhaustedError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = this.constructor.name
   }
 }
 

--- a/lib/querytypes.ts
+++ b/lib/querytypes.ts
@@ -350,6 +350,8 @@ export interface QueryOptions {
 
   /**
    * Specifies the maximum number of retries for this query. If unset, defaults to the cluster-level maxRetries.
+   *
+   * Volatile: This API is subject to change at any time.
    */
   maxRetries?: number
 

--- a/lib/requestcontext.ts
+++ b/lib/requestcontext.ts
@@ -34,16 +34,16 @@ export class RequestContext {
   /**
    * @internal
    */
-  incrementAttempt(): void {
-    this._numAttempts++
-    this._errorContext.numAttempts = this._numAttempts
+  get maxRetryAttempts(): number {
+    return this._maxRetryAttempts
   }
 
   /**
    * @internal
    */
-  retriesExceeded(): boolean {
-    return this._numAttempts > this._maxRetryAttempts
+  incrementAttempt(): void {
+    this._numAttempts++
+    this._errorContext.numAttempts = this._numAttempts
   }
 
   /**
@@ -73,13 +73,6 @@ export class RequestContext {
   /**
    * @internal
    */
-  setPreviousAttemptErrors(errors: any): void {
-    this._errorContext.previousAttemptErrors = errors
-  }
-
-  /**
-   * @internal
-   */
   pushOtherServerErrors(...errors: any): void {
     this._errorContext.otherServerErrors.push(errors)
   }
@@ -89,5 +82,14 @@ export class RequestContext {
    */
   attachErrorContext(message: string): string {
     return `${message}. ${this._errorContext.toString()}`
+  }
+
+  /**
+   * @internal
+   */
+  addPreviousAttemptErrorToContext(errors: any): void {
+    if (errors) {
+      this._errorContext.previousAttemptErrors = errors
+    }
   }
 }


### PR DESCRIPTION
Changes:
- Buffer whole response if we get a non-successful status code
- Store final error in case retries exceeded