### PR TITLE
Switch __dirname in copyCertiicates to backwards compatible version

### DIFF
--- a/scripts/copyCertificates.js
+++ b/scripts/copyCertificates.js
@@ -17,8 +17,9 @@
 
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'node:url'
 
-const __dirname = import.meta.dirname
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const CERT_DIRS = [
   { src: 'nonProdCertificates', dest: 'nonProdCertificates' },


### PR DESCRIPTION
`import.meta.dirname` does not exist on Node versions <20.11.0, this change allows for backwards compatibility when building with earlier Node versions.